### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: Rust CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/0x53A/ractor-wormhole/security/code-scanning/2](https://github.com/0x53A/ractor-wormhole/security/code-scanning/2)

To fix this issue, explicitly limit GITHUB_TOKEN permissions in the workflow YAML file. The safest default is at least `contents: read`, which suffices for workflows that only need to read source code and do not need to perform GitHub write actions such as creating issues, pull requests, deployments, etc. You should add a `permissions` block—either at the workflow root level or inside each job, but the root level is preferred here for simplicity and uniform restriction of all jobs. Edit the `.github/workflows/ci.yml` file by adding:
```yaml
permissions:
  contents: read
```
directly after the workflow name, so that the least privileges required are in force for all jobs. No additional imports or dependencies are required; only the workflow YAML file needs to be edited.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
